### PR TITLE
Feature/height

### DIFF
--- a/src/cmsplugin_filer_image/cms_plugins.py
+++ b/src/cmsplugin_filer_image/cms_plugins.py
@@ -43,6 +43,7 @@ class FilerImagePlugin(CMSPluginBase):
         crop, upscale = False, False
         subject_location = False
         placeholder_width = context.get('width', None)
+        placeholder_height = context.get('height', None)
         if instance.thumbnail_option:
             # thumbnail option overrides everything else
             if instance.thumbnail_option.width:
@@ -57,7 +58,9 @@ class FilerImagePlugin(CMSPluginBase):
                 width = int(placeholder_width)
             elif instance.width:
                 width = instance.width
-            if instance.height:
+            if instance.use_autoscale and placeholder_height:
+                height = int(placeholder_height)
+            elif instance.height:
                 height = instance.height
             crop = instance.crop
             upscale = instance.upscale


### PR DESCRIPTION
I often find it useful to specify height as well as width for a placeholder (for specific teaser or image areas). This branch adds this feature to the image and teaser plugin - picking up height from either CMS_PLACEHOLDER_CONF or a template variable 'height'. Is it something you would consider adding? 
