### PR TITLE
Using filer's video icon for video plugin.

### DIFF
--- a/src/cmsplugin_filer_video/cms_plugins.py
+++ b/src/cmsplugin_filer_video/cms_plugins.py
@@ -59,6 +59,5 @@ class FilerVideoPlugin(CMSPluginBase):
         return context
     
     def icon_src(self, instance):
-        # TODO: Use real video icon where there will be one
-        return os.path.normpath(u"%s/icons/file_%sx%s.png" % (FILER_STATICMEDIA_PREFIX, 32, 32,))
+        return os.path.normpath(u"%s/icons/video_%sx%s.png" % (FILER_STATICMEDIA_PREFIX, 32, 32,))
 plugin_pool.register_plugin(FilerVideoPlugin)


### PR DESCRIPTION
With django-filer's issue 95 now we can use that icon for the plugin.
