### PR TITLE
Display files in folder in the order displayed in the admin.

### DIFF
--- a/src/cmsplugin_filer_folder/cms_plugins.py
+++ b/src/cmsplugin_filer_folder/cms_plugins.py
@@ -44,8 +44,8 @@ class FilerFolderPlugin(CMSPluginBase):
         
         context.update({
             'object': instance,
-            'folder_files': folder_files,
-            'folder_images': folder_images,
+            'folder_files': sorted(folder_files),
+            'folder_images': sorted(folder_images),
             'folder_folders': folder_folders,
             'placeholder': placeholder
         })    


### PR DESCRIPTION
`sorted()` works on files with my pull request for django-filer. So we can use it also here and get predictable display order.
