### PR TITLE
Added ability to change filer folder view options from main settings file

### DIFF
--- a/src/cmsplugin_filer_folder/models.py
+++ b/src/cmsplugin_filer_folder/models.py
@@ -6,10 +6,7 @@ from posixpath import join, basename, splitext, exists
 from filer.fields.folder import FilerFolderField
 from django.conf import settings
 
-VIEW_OPTIONS = (
-    ("list", _("List")),
-    ("slideshow", _("Slideshow"))
-)
+VIEW_OPTIONS = getattr(settings, 'CMSPLUGIN_FILER_FOLDER_VIEW_OPTIONS', (("list", _("List")),("slideshow",_("Slideshow"))))
 
 class FilerFolder(CMSPlugin):
     """


### PR DESCRIPTION
Added ability to change filer folder view options from main settings file.
if  CMSPLUGIN_FILER_FOLDER_VIEW_OPTIONS is defined in settings it will be taken into use
default is still the same:
(
 ("list", _("List")),
 ("slideshow",_("Slideshow"))
)
