### PR TITLE
Fixed manifest file so that media/static files are included.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include README.rst
 include HISTORY
 recursive-include src/*/templates *
+recursive-include src/*/media *


### PR DESCRIPTION
Media/static files were not included in installation. This fixes it. Should probably be updated with #41.
