### PR TITLE
added a manager that automatically adds the filer FKs to ``select_related``

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -6,6 +6,7 @@ from posixpath import join, basename, splitext, exists
 from filer.fields.image import FilerImageField
 from filer.fields.file import FilerFileField
 from django.conf import settings
+from cmsplugin_filer_utils import FilerPluginManager
 
 
 class FilerFile(CMSPlugin):
@@ -27,6 +28,8 @@ class FilerFile(CMSPlugin):
     """
     title = models.CharField(_("title"), max_length=255, null=True, blank=True)
     file = FilerFileField()
+
+    objects = FilerPluginManager(select_related=('file',))
     
     def get_icon_url(self):
         return self.file.icons['32']

--- a/cmsplugin_filer_folder/models.py
+++ b/cmsplugin_filer_folder/models.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from posixpath import join, basename, splitext, exists
 from filer.fields.folder import FilerFolderField
 from django.conf import settings
+from cmsplugin_filer_utils import FilerPluginManager
 
 VIEW_OPTIONS = getattr(settings, 'CMSPLUGIN_FILER_FOLDER_VIEW_OPTIONS', (("list", _("List")),("slideshow",_("Slideshow"))))
 
@@ -18,14 +19,15 @@ class FilerFolder(CMSPlugin):
     view_option = models.CharField(_("view option"),max_length=10,
                             choices=VIEW_OPTIONS, default="list")
     folder = FilerFolderField()
-    
+
+    objects = FilerPluginManager(select_related=('folder',))
         
     def __unicode__(self):
         if self.title: 
-            return self.title;
+            return self.title
         elif self.folder.name:
             # added if, because it raised attribute error when file wasnt defined
-            return self.folder.name;
+            return self.folder.name
         return "<empty>"
 
     search_fields = ('title',)

--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -7,6 +7,8 @@ from filer.fields.image import FilerImageField
 from filer.fields.file import FilerFileField
 from cms import settings as cms_settings
 from django.conf import settings
+from cmsplugin_filer_utils import FilerPluginManager
+
 
 class FilerImage(CMSPlugin):
     LEFT = "left"
@@ -35,7 +37,13 @@ class FilerImage(CMSPlugin):
     file_link = FilerFileField(null=True, blank=True, default=None, verbose_name=_("file link"), help_text=_("if present image will be clickable"), related_name='+')
     original_link = models.BooleanField(_("link original image"), default=False, help_text=_("if present image will be clickable"))
     description = models.TextField(_("description"), blank=True, null=True)
-    
+
+    # we only add the image to select_related. page_link and file_link are FKs
+    # as well, but they are not used often enough to warrant the impact of two
+    # additional LEFT OUTER JOINs.
+    objects = FilerPluginManager(select_related=('image',))
+
+
     class Meta:
         verbose_name = _("filer image")
         verbose_name_plural = _("filer images")

--- a/cmsplugin_filer_teaser/models.py
+++ b/cmsplugin_filer_teaser/models.py
@@ -5,6 +5,8 @@ from cms.models.fields import PageField
 from filer.fields.image import FilerImageField
 from django.conf import settings
 
+from cmsplugin_filer_utils import FilerPluginManager
+
 CMSPLUGIN_FILER_TEASER_STYLE_CHOICES = getattr( settings, 'CMSPLUGIN_FILER_TEASER_STYLE_CHOICES',() )
 
 class FilerTeaser(CMSPlugin):
@@ -27,6 +29,8 @@ class FilerTeaser(CMSPlugin):
     description = models.TextField(_("description"), blank=True, null=True)
     
     target_blank = models.BooleanField(_("open link in new window"), default=False)
+
+    objects = FilerPluginManager(select_related=('image', 'page_link'))
     
     def clean(self):
         from django.core.exceptions import ValidationError

--- a/cmsplugin_filer_utils/__init__.py
+++ b/cmsplugin_filer_utils/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from django.db import models
+
+
+class FilerPluginManager(models.Manager):
+    def __init__(self, select_related=None):
+        self._select_related = select_related
+        super(FilerPluginManager, self).__init__()
+
+    def get_query_set(self):
+        qs = super(FilerPluginManager, self).get_query_set()
+        if self._select_related:
+            qs = qs.select_related(*self._select_related)
+        return qs


### PR DESCRIPTION
This saves at least one query per plugin, but also adds a JOIN where there was none before. But I still think it's a good trade off. 

Also, I couldn't resist removing those two semicolons ;)
