### PR TITLE
Django 1.5: remove obsolete verify_exists option from URLField's

### DIFF
--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -1,3 +1,4 @@
+import django
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from cms.models import CMSPlugin, Page
@@ -8,6 +9,7 @@ from filer.fields.file import FilerFileField
 from cms import settings as cms_settings
 from django.conf import settings
 from cmsplugin_filer_utils import FilerPluginManager
+from distutils.version import LooseVersion
 
 
 class FilerImage(CMSPlugin):
@@ -18,7 +20,10 @@ class FilerImage(CMSPlugin):
                      )
     caption_text = models.CharField(_("caption text"), null=True, blank=True, max_length=255)
     image = FilerImageField(null=True, blank=True, default=None, verbose_name=_("image"))
-    image_url = models.URLField(_("alternative image url"), null=True, blank=True, default=None)
+    if LooseVersion(django.get_version()) < LooseVersion('1.5'):
+        image_url = models.URLField(_("alternative image url"), verify_exists=False, null=True, blank=True, default=None)
+    else:
+        image_url = models.URLField(_("alternative image url"), null=True, blank=True, default=None)
     alt_text = models.CharField(_("alt text"), null=True, blank=True, max_length=255)
     thumbnail_option = models.ForeignKey('ThumbnailOption', null=True, blank=True, verbose_name=_("thumbnail option"))
     use_autoscale = models.BooleanField(_("use automatic scaling"), default=False, 

--- a/cmsplugin_filer_teaser/models.py
+++ b/cmsplugin_filer_teaser/models.py
@@ -1,9 +1,11 @@
+import django
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from cms.models import CMSPlugin
 from cms.models.fields import PageField
 from filer.fields.image import FilerImageField
 from django.conf import settings
+from distutils.version import LooseVersion
 
 from cmsplugin_filer_utils import FilerPluginManager
 
@@ -15,7 +17,10 @@ class FilerTeaser(CMSPlugin):
     """
     title = models.CharField(_("title"), max_length=255, blank=True)
     image = FilerImageField(blank=True, null=True, verbose_name=_("image"))
-    image_url = models.URLField(_("alternative image url"), null=True, blank=True, default=None)
+    if LooseVersion(django.get_version()) < LooseVersion('1.5'):
+        image_url = models.URLField(_("alternative image url"), verify_exists=False, null=True, blank=True, default=None)
+    else:
+        image_url = models.URLField(_("alternative image url"), null=True, blank=True, default=None)
     
     style = models.CharField(_("teaser style"), max_length=255, null=True, blank=True, choices=CMSPLUGIN_FILER_TEASER_STYLE_CHOICES)
     


### PR DESCRIPTION
minor compatibility fix
