### PR TITLE
ThumbnailOption.as_dict

### DIFF
--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -120,4 +120,5 @@ class ThumbnailOption(models.Model):
             thumbnailer = filerimage.easy_thumbnails_thumbnailer
             thumb_image = thumbnailer.get_thumbnail(option_dict)
         """
-        return {"size":(self.width,self.height), "width":self.width,"height":self.height,"crop":self.crop,"upscale":self.upscale}
+        return {"size":(self.width,self.height), "width":self.width,
+                "height":self.height,"crop":self.crop,"upscale":self.upscale}


### PR DESCRIPTION
Added `as_dict` property to `ThumbnailOption`: it returns a thumbnailer-compatible dictionary.

This is mostly useful if using `ThumbnailOption` as a general model for filer as I do (see #79)
