### PR TITLE
Make FileFile.get_file_name cope with sitiuations where self.file.name is not set.

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -32,7 +32,11 @@ class FilerFile(CMSPlugin):
         return exists(self.file.path)
 
     def get_file_name(self):
-        return self.file.name
+        if self.file.name in ('', None):
+            name = u"%s" % (self.file.original_filename,)
+        else:
+            name = u"%s" % (self.file.name,)
+        return name
 
     def get_ext(self):
         return self.file.extension


### PR DESCRIPTION
Issue reproduced with:
django-filer==0.9
django-cms==2.3.3
django==1.4.1

Steps to reproduce:
1. Upload a file to filer (foo_file)
2. In any page add a filer file plugin that points to the file you've just added

Expected:
- plugin successfully added

Actual :
AttributeError at /admin/cms/page/2/edit-plugin/8/
'FilerFile' object has no attribute 'name'

File "/home/kux/workspace/src/other/django/django/core/handlers/base.py" in get_response
1.                         response = callback(request, _callback_args, *_callback_kwargs)
   File "/home/kux/workspace/src/other/django/django/utils/decorators.py" in _wrapped_view
2.                     response = view_func(request, _args, *_kwargs)
   File "/home/kux/workspace/src/other/django/django/views/decorators/cache.py" in _wrapped_view_func
3.         response = view_func(request, _args, *_kwargs)
   File "/home/kux/workspace/src/other/django/django/contrib/admin/sites.py" in inner
4.             return view(request, _args, *_kwargs)
   File "/home/kux/workspace/envs/contribute/local/lib/python2.7/site-packages/reversion/revisions.py" in do_revision_context
5.                     return func(_args, *_kwargs)
   File "/home/kux/workspace/src/other/django-cms/cms/admin/pageadmin.py" in edit_plugin
6.             response = plugin_admin.add_view(request)
   File "/home/kux/workspace/src/other/django/django/utils/decorators.py" in _wrapper
7.             return bound_func(_args, *_kwargs)
   File "/home/kux/workspace/src/other/django/django/utils/decorators.py" in _wrapped_view
8.                     response = view_func(request, _args, *_kwargs)
   File "/home/kux/workspace/src/other/django/django/utils/decorators.py" in bound_func
9.                 return func(self, _args2, *_kwargs2)
   File "/home/kux/workspace/src/other/django/django/db/transaction.py" in inner
10.                 return func(_args, *_kwargs)
    File "/home/kux/workspace/src/other/django/django/contrib/admin/options.py" in add_view
11.                 return self.response_add(request, new_object)
    File "/home/kux/workspace/src/other/django-cms/cms/plugin_base.py" in response_add
12.         return super(CMSPluginBase, self).response_add(request, obj)
    File "/home/kux/workspace/src/other/django/django/contrib/admin/options.py" in response_add
13.         msg = _('The %(name)s "%(obj)s" was added successfully.') % {'name': force_unicode(opts.verbose_name), 'obj': force_unicode(obj)}
    File "/home/kux/workspace/src/other/django/django/utils/encoding.py" in force_unicode
14.                 s = unicode(s)
    File "/home/kux/workspace/src/other/cmsplugin-filer/cmsplugin_filer_file/models.py" in **unicode**
15.             return self.get_file_name()
    File "/home/kux/workspace/src/other/cmsplugin-filer/cmsplugin_filer_file/models.py" in get_file_name
16.         return self.name

Exception Type: AttributeError at /admin/cms/page/2/edit-plugin/8/
Exception Value: 'FilerFile' object has no attribute 'name'
