### PR TITLE
Fix for issue 81

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -30,11 +30,7 @@ class FilerFile(CMSPlugin):
         return self.file.file.storage.exists(self.file.path)
 
     def get_file_name(self):
-        if self.file.name in ('', None):
-            name = u"%s" % (self.file.original_filename,)
-        else:
-            name = u"%s" % (self.file.name,)
-        return name
+        return self.file.name
 
     def get_ext(self):
         return self.file.extension


### PR DESCRIPTION
Use the file's storage to determine whether the file exists or not.

The existing implementation that uses posixpath.exists only works if the storage backend is the default FileSystemStorage.

See attached image for a screenshot of the bug.
Mind that if clicking on the file's link you do actually see the file (the file is there, even though it's reported as missing).

![file_missing](https://f.cloud.github.com/assets/568447/65091/4e3db75c-5e69-11e2-8cc3-e3a4bee8660d.png)
