### PR TITLE
Removed dependency on nonexistent filer migration.

### DIFF
--- a/cmsplugin_filer_file/migrations/0001_initial.py
+++ b/cmsplugin_filer_file/migrations/0001_initial.py
@@ -5,12 +5,8 @@ from cmsplugin_filer_file.models import *
 
 class Migration:
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerFile'
         db.create_table('cmsplugin_filerfile', (
             ('cmsplugin_ptr', orm['cmsplugin_filer_file.FilerFile:cmsplugin_ptr']),
@@ -18,16 +14,14 @@ class Migration:
             ('title', orm['cmsplugin_filer_file.FilerFile:title']),
         ))
         db.send_create_signal('cmsplugin_filer_file', ['FilerFile'])
-        
-    
-    
+
+
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerFile'
         db.delete_table('cmsplugin_filerfile')
-        
-    
-    
+
+
     models = {
         'auth.group': {
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -146,5 +140,5 @@ class Migration:
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         }
     }
-    
+
     complete_apps = ['cmsplugin_filer_file']

--- a/cmsplugin_filer_folder/migrations/0001_initial.py
+++ b/cmsplugin_filer_folder/migrations/0001_initial.py
@@ -6,12 +6,8 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerFolder'
         db.create_table('cmsplugin_filerfolder', (
             ('cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
@@ -23,7 +19,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerFolder'
         db.delete_table('cmsplugin_filerfolder')
 

--- a/cmsplugin_filer_image/migrations/0001_initial.py
+++ b/cmsplugin_filer_image/migrations/0001_initial.py
@@ -5,12 +5,8 @@ from cmsplugin_filer_image.models import *
 
 class Migration:
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerImage'
         db.create_table('cmsplugin_filerimage', (
             ('cmsplugin_ptr', orm['cmsplugin_filer_image.FilerImage:cmsplugin_ptr']),
@@ -26,16 +22,14 @@ class Migration:
             ('description', orm['cmsplugin_filer_image.FilerImage:description']),
         ))
         db.send_create_signal('cmsplugin_filer_image', ['FilerImage'])
-        
-    
-    
+
+
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerImage'
         db.delete_table('cmsplugin_filerimage')
-        
-    
-    
+
+
     models = {
         'auth.group': {
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -174,5 +168,5 @@ class Migration:
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         }
     }
-    
+
     complete_apps = ['cmsplugin_filer_image']

--- a/cmsplugin_filer_link/migrations/0001_initial.py
+++ b/cmsplugin_filer_link/migrations/0001_initial.py
@@ -6,12 +6,8 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerLinkPlugin'
         db.create_table('cmsplugin_filerlinkplugin', (
             ('cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
@@ -27,7 +23,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerLinkPlugin'
         db.delete_table('cmsplugin_filerlinkplugin')
 

--- a/cmsplugin_filer_teaser/migrations/0001_initial.py
+++ b/cmsplugin_filer_teaser/migrations/0001_initial.py
@@ -5,12 +5,8 @@ from cmsplugin_filer_teaser.models import *
 
 class Migration:
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerTeaser'
         db.create_table('cmsplugin_filerteaser', (
             ('cmsplugin_ptr', orm['cmsplugin_filer_teaser.FilerTeaser:cmsplugin_ptr']),
@@ -24,16 +20,14 @@ class Migration:
             ('description', orm['cmsplugin_filer_teaser.FilerTeaser:description']),
         ))
         db.send_create_signal('cmsplugin_filer_teaser', ['FilerTeaser'])
-        
-    
-    
+
+
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerTeaser'
         db.delete_table('cmsplugin_filerteaser')
-        
-    
-    
+
+
     models = {
         'auth.group': {
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -170,5 +164,5 @@ class Migration:
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         }
     }
-    
+
     complete_apps = ['cmsplugin_filer_teaser']

--- a/cmsplugin_filer_video/migrations/0001_initial.py
+++ b/cmsplugin_filer_video/migrations/0001_initial.py
@@ -6,12 +6,8 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
-    depends_on = (
-        ("filer", "0008_polymorphic__del_field_file__file_type_plugin_name"),
-        )
-
     def forwards(self, orm):
-        
+
         # Adding model 'FilerVideo'
         db.create_table('cmsplugin_filervideo', (
             ('cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
@@ -37,7 +33,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Deleting model 'FilerVideo'
         db.delete_table('cmsplugin_filervideo')
 


### PR DESCRIPTION
The migrations were squashed in https://github.com/stefanfoulis/django-filer/commit/fc1686dfd821d66bab3aab9cbbc5f5dad24df289

It's no longer possible to run these migrations due to the missing dependency.
