### PR TITLE
Use prefetch related to trigger polymorphic downcast.

### DIFF
--- a/cmsplugin_filer_utils/__init__.py
+++ b/cmsplugin_filer_utils/__init__.py
@@ -10,5 +10,5 @@ class FilerPluginManager(models.Manager):
     def get_query_set(self):
         qs = super(FilerPluginManager, self).get_query_set()
         if self._select_related:
-            qs = qs.select_related(*self._select_related)
+            qs = qs.prefetch_related(*self._select_related)
         return qs


### PR DESCRIPTION
Under some circumstances, the filer File object is not correctly casted to the relevant child class.
Using prefetch_related triggers the casting more reliably.
This may cause a little performance hit, but the whole `file` attribute (the only 'real' case in cmsplugin-filer for this code to be executed) is going to be retrieved anyway in nearly all cases so this is not going to be much relevant
