### PR TITLE
Fixes for cmsplugin_filer_link (DOCO and bug fix)

### DIFF
--- a/cmsplugin_filer_link/cms_plugins.py
+++ b/cmsplugin_filer_link/cms_plugins.py
@@ -12,7 +12,6 @@ class FilerLinkPlugin(CMSPluginBase):
     model = FilerLinkPlugin
     name = _("Link")
     text_enabled = True
-    raw_id_fields = ('page_link', )
     render_template = "cmsplugin_filer_link/link.html"
 
     def render(self, context, instance, placeholder):


### PR DESCRIPTION
- Added missing app to README installation instructions.
- Add "page_link" to "raw_id_fields" to prevent the run of "decompress". This is the same issue as the already merged pull request for issue #106 that was for cmsplugin_filer_image however this applies to cmsplugin_filer_link app
