### PR TITLE
Fixes AttributeError when trying to save teaser.

### DIFF
--- a/cmsplugin_filer_teaser/cms_plugins.py
+++ b/cmsplugin_filer_teaser/cms_plugins.py
@@ -13,6 +13,7 @@ class FilerTeaserPlugin(CMSPluginBase):
     """
     module = 'Filer'
     model = models.FilerTeaser
+    raw_id_fields = ('page_link',)
     name = _("Teaser")
     TEMPLATE_NAME = 'cmsplugin_filer_teaser/plugins/teaser/%s.html'
     render_template = TEMPLATE_NAME % 'default'


### PR DESCRIPTION
The full error is AttributeError: 'RelatedFieldWidgetWrapper' object has no attribute 'decompress'.

This is the same as the fix in issue #106 but for the teaser widget.
