### PR TITLE
Restores Django 1.7 migrations support

### DIFF
--- a/cmsplugin_filer_file/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_file/migrations_django/0001_initial.py
@@ -2,13 +2,14 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.conf import settings
 import filer.fields.file
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '0001_initial'),
     ]
 
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
                 ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
                 ('title', models.CharField(max_length=255, null=True, verbose_name='title', blank=True)),
                 ('target_blank', models.BooleanField(default=False, verbose_name='Open link in new window')),
-                ('style', models.CharField(default=b'', max_length=255, verbose_name='Style', blank=True)),
+                ('style', models.CharField(default=settings.CMSPLUGIN_FILER_FILE_DEFAULT_STYLE, choices=settings.CMSPLUGIN_FILER_FILE_STYLE_CHOICES, verbose_name='Style', blank=True, max_length=255)),
                 ('file', filer.fields.file.FilerFileField(verbose_name='file', to='filer.File')),
             ],
             options={

--- a/cmsplugin_filer_folder/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_folder/migrations_django/0001_initial.py
@@ -2,13 +2,14 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.conf import settings
 import filer.fields.folder
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '0001_initial'),
     ]
 
@@ -18,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
                 ('title', models.CharField(max_length=255, null=True, verbose_name='title', blank=True)),
-                ('style', models.CharField(default=b'list', max_length=50, verbose_name='Style', choices=[(b'list', 'List'), (b'slideshow', 'Slideshow')])),
+                ('style', models.CharField(default=settings.CMSPLUGIN_FILER_FOLDER_DEFAULT_STYLE, max_length=50, verbose_name='Style', choices=settings.CMSPLUGIN_FILER_FOLDER_STYLE_CHOICES)),
                 ('folder', filer.fields.folder.FilerFolderField(to='filer.Folder')),
             ],
             options={

--- a/cmsplugin_filer_image/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_image/migrations_django/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.conf import settings
 import filer.fields.file
 import filer.fields.image
 import cms.models.fields
@@ -10,7 +11,7 @@ import cms.models.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '0001_initial'),
     ]
 
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
             name='FilerImage',
             fields=[
                 ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
-                ('style', models.CharField(default=b'', max_length=50, verbose_name='Style', blank=True)),
+                ('style', models.CharField(max_length=50, verbose_name='Style', default=settings.CMSPLUGIN_FILER_IMAGE_DEFAULT_STYLE, blank=True, choices=settings.CMSPLUGIN_FILER_IMAGE_STYLE_CHOICES)),
                 ('caption_text', models.CharField(max_length=255, null=True, verbose_name='caption text', blank=True)),
                 ('image_url', models.URLField(default=None, null=True, verbose_name='alternative image url', blank=True)),
                 ('alt_text', models.CharField(max_length=255, null=True, verbose_name='alt text', blank=True)),

--- a/cmsplugin_filer_link/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_link/migrations_django/0001_initial.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import filer.fields.file
 import cms.models.fields
+from cmsplugin_filer_link.models import LINK_STYLES
 
 
 class Migration(migrations.Migration):
@@ -21,7 +22,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255, verbose_name='name')),
                 ('url', models.CharField(max_length=255, null=True, verbose_name='url', blank=True)),
                 ('mailto', models.EmailField(help_text='An email address has priority over both pages and urls', max_length=75, null=True, verbose_name='mailto', blank=True)),
-                ('link_style', models.CharField(default=b' ', max_length=255, verbose_name='link style', choices=[(b' ', b'Default')])),
+                ('link_style', models.CharField(max_length=255, verbose_name='link style', default=LINK_STYLES[0][0], choices=LINK_STYLES)),
                 ('new_window', models.BooleanField(default=False, help_text='Do you want this link to open a new window?', verbose_name='new window?')),
                 ('file', filer.fields.file.FilerFileField(blank=True, to='filer.File', null=True)),
                 ('page_link', cms.models.fields.PageField(blank=True, to='cms.Page', help_text='A link to a page has priority over urls.', null=True, verbose_name='page')),

--- a/cmsplugin_filer_teaser/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_teaser/migrations_django/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.conf import settings
 import filer.fields.image
 import cms.models.fields
 
@@ -9,7 +10,7 @@ import cms.models.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '0001_initial'),
     ]
 
@@ -20,7 +21,7 @@ class Migration(migrations.Migration):
                 ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
                 ('title', models.CharField(max_length=255, verbose_name='title', blank=True)),
                 ('image_url', models.URLField(default=None, null=True, verbose_name='alternative image url', blank=True)),
-                ('style', models.CharField(default=b'', max_length=255, verbose_name='Style', blank=True)),
+                ('style', models.CharField(max_length=255, blank=True, default=settings.CMSPLUGIN_FILER_TEASER_DEFAULT_STYLE, choices=settings.CMSPLUGIN_FILER_TEASER_STYLE_CHOICES, verbose_name='Style')),
                 ('use_autoscale', models.BooleanField(default=True, help_text='tries to auto scale the image based on the placeholder context', verbose_name='use automatic scaling')),
                 ('width', models.PositiveIntegerField(null=True, verbose_name='width', blank=True)),
                 ('height', models.PositiveIntegerField(null=True, verbose_name='height', blank=True)),

--- a/cmsplugin_filer_video/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_video/migrations_django/0001_initial.py
@@ -4,12 +4,13 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import filer.fields.image
 import filer.fields.file
+from cmsplugin_filer_video import settings
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '0001_initial'),
     ]
 
@@ -19,22 +20,22 @@ class Migration(migrations.Migration):
             fields=[
                 ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
                 ('movie_url', models.CharField(help_text='vimeo or youtube video url. Example: http://www.youtube.com/watch?v=YFa59lK-kpo', max_length=255, null=True, verbose_name='movie url', blank=True)),
-                ('width', models.PositiveSmallIntegerField(default=320, verbose_name='width')),
-                ('height', models.PositiveSmallIntegerField(default=240, verbose_name='height')),
-                ('auto_play', models.BooleanField(default=False, verbose_name='auto play')),
-                ('auto_hide', models.BooleanField(default=False, verbose_name='auto hide')),
-                ('fullscreen', models.BooleanField(default=True, verbose_name='fullscreen')),
-                ('loop', models.BooleanField(default=False, verbose_name='loop')),
-                ('bgcolor', models.CharField(default=b'000000', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='background color')),
-                ('textcolor', models.CharField(default=b'FFFFFF', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='text color')),
-                ('seekbarcolor', models.CharField(default=b'13ABEC', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='seekbar color')),
-                ('seekbarbgcolor', models.CharField(default=b'333333', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='seekbar bg color')),
-                ('loadingbarcolor', models.CharField(default=b'828282', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='loadingbar color')),
-                ('buttonoutcolor', models.CharField(default=b'333333', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='button out color')),
-                ('buttonovercolor', models.CharField(default=b'000000', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='button over color')),
-                ('buttonhighlightcolor', models.CharField(default=b'FFFFFF', help_text='Hexadecimal, eg ff00cc', max_length=6, verbose_name='button highlight color')),
-                ('image', filer.fields.image.FilerImageField(related_name='filer_video_image', blank=True, to='filer.Image', help_text='preview image file', null=True, verbose_name='image')),
-                ('movie', filer.fields.file.FilerFileField(blank=True, to='filer.File', help_text='use .flv file or h264 encoded video file', null=True, verbose_name='movie file')),
+                ('width', models.PositiveSmallIntegerField(verbose_name='width', default=settings.VIDEO_WIDTH)),
+                ('height', models.PositiveSmallIntegerField(verbose_name='height', default=settings.VIDEO_HEIGHT)),
+                ('auto_play', models.BooleanField(verbose_name='auto play', default=settings.VIDEO_AUTOPLAY)),
+                ('auto_hide', models.BooleanField(verbose_name='auto hide', default=settings.VIDEO_AUTOHIDE)),
+                ('fullscreen', models.BooleanField(verbose_name='fullscreen', default=settings.VIDEO_FULLSCREEN)),
+                ('loop', models.BooleanField(verbose_name='loop', default=settings.VIDEO_LOOP)),
+                ('bgcolor', models.CharField(default=settings.VIDEO_BG_COLOR, max_length=6, verbose_name='background color', help_text='Hexadecimal, eg ff00cc')),
+                ('textcolor', models.CharField(default=settings.VIDEO_TEXT_COLOR, max_length=6, verbose_name='text color', help_text='Hexadecimal, eg ff00cc')),
+                ('seekbarcolor', models.CharField(default=settings.VIDEO_SEEKBAR_COLOR, max_length=6, verbose_name='seekbar color', help_text='Hexadecimal, eg ff00cc')),
+                ('seekbarbgcolor', models.CharField(default=settings.VIDEO_SEEKBARBG_COLOR, max_length=6, verbose_name='seekbar bg color', help_text='Hexadecimal, eg ff00cc')),
+                ('loadingbarcolor', models.CharField(default=settings.VIDEO_LOADINGBAR_COLOR, max_length=6, verbose_name='loadingbar color', help_text='Hexadecimal, eg ff00cc')),
+                ('buttonoutcolor', models.CharField(default=settings.VIDEO_BUTTON_OUT_COLOR, max_length=6, verbose_name='button out color', help_text='Hexadecimal, eg ff00cc')),
+                ('buttonovercolor', models.CharField(default=settings.VIDEO_BUTTON_OVER_COLOR, max_length=6, verbose_name='button over color', help_text='Hexadecimal, eg ff00cc')),
+                ('buttonhighlightcolor', models.CharField(default=settings.VIDEO_BUTTON_HIGHLIGHT_COLOR, max_length=6, verbose_name='button highlight color', help_text='Hexadecimal, eg ff00cc')),
+                ('image', filer.fields.image.FilerImageField(null=True, to='filer.Image', help_text='preview image file', related_name='filer_video_image', blank=True, verbose_name='image')),
+                ('movie', filer.fields.file.FilerFileField(null=True, to='filer.File', help_text='use .flv file or h264 encoded video file', blank=True, verbose_name='movie file')),
             ],
             options={
                 'abstract': False,


### PR DESCRIPTION
User configurable choices/default have to be dynamic in the migrations. Also, this only works with django-cms support/3.0.x branch, the develop branch is not yet compatible.

This fixes the mistakes introduced by #149 
