### PR TITLE
One more Django 1.7 migrations fix

### DIFF
--- a/cmsplugin_filer_link/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_link/migrations_django/0001_initial.py
@@ -10,7 +10,7 @@ from cmsplugin_filer_link.models import LINK_STYLES
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0004_auto_20141015_0046'),
+        ('cms', '0004_auto_20140924_1038'),
         ('filer', '0001_initial'),
     ]
 


### PR DESCRIPTION
Sorry, one last fix. I missed the migrations rename in the initial migration for the link plugin
