### PR TITLE
support fixed filer migrations (to properly handle custom Image model)

### DIFF
--- a/cmsplugin_filer_image/migrations_django/0001_initial.py
+++ b/cmsplugin_filer_image/migrations_django/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0003_auto_20140926_2347'),
-        ('filer', '0001_initial'),
+        ('filer', '0002_image'),
     ]
 
     operations = [


### PR DESCRIPTION
In case filer's pull request #471 (https://github.com/stefanfoulis/django-filer/pull/471) is good, this should be applied to fix cmsplugin_filer_image
