### PR TITLE
Set FilerLinkPlugin.mailto max_length to 75

### DIFF
--- a/cmsplugin_filer_link/models.py
+++ b/cmsplugin_filer_link/models.py
@@ -19,7 +19,7 @@ class FilerLinkPlugin(CMSPlugin):
     url = models.CharField(_("url"), blank=True, null=True, max_length=255)
     page_link = PageField(verbose_name=_("page"), blank=True, null=True,
              help_text=_("A link to a page has priority over urls."))
-    mailto = models.EmailField(_("mailto"), blank=True, null=True,
+    mailto = models.EmailField(_("mailto"), blank=True, null=True, max_length=75,
              help_text=_("An email address has priority over both pages and urls"))
     link_style = models.CharField(_("link style"), max_length=255,
                 choices=LINK_STYLES, default=LINK_STYLES[0][0])


### PR DESCRIPTION
This will prevent Django1.8 to want new migration for this plugin. This is related to
https://docs.djangoproject.com/en/1.8/releases/1.8/#default-emailfield-max-length-increased-to-254

Probably will be good to also increase default size of the email but this will make extra problems with other pull request which have migrations in them (especially South migrations). For that reason I decided to just set default length as of prior Django 1.8