### PR TITLE
Add Django 1.9 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 env:
     - TOXENV=flake8
+    - TOXENV=py27-dj19-cms31
     - TOXENV=py27-dj18-cms31
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 env:
     - TOXENV=flake8
-    - TOXENV=py27-dj19-cms31
+    - TOXENV=py27-dj19-cms32
     - TOXENV=py27-dj18-cms31
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30

--- a/cmsplugin_filer_file/cms_plugins.py
+++ b/cmsplugin_filer_file/cms_plugins.py
@@ -20,7 +20,7 @@ class FilerFilePlugin(CMSPluginBase):
     fieldsets = (
         (None, {'fields': [
             'title',
-            'file',
+            'source',
             'target_blank'
         ]}),
     )

--- a/cmsplugin_filer_file/migrations/0006_rename_file_col.py
+++ b/cmsplugin_filer_file/migrations/0006_rename_file_col.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.rename_column(u'cmsplugin_filer_file_filerfile', 'file', 'source')
+
+    def backwards(self, orm):
+        db.rename_column(u'cmsplugin_filer_file_filerfile', 'source', 'file')
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'cmsplugin_filer_file.filerfile': {
+            'Meta': {'object_name': 'FilerFile', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'file': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
+            'target_blank': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['cmsplugin_filer_file']

--- a/cmsplugin_filer_file/migrations/0006_rename_file_col.py
+++ b/cmsplugin_filer_file/migrations/0006_rename_file_col.py
@@ -8,10 +8,10 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        db.rename_column(u'cmsplugin_filer_file_filerfile', 'file', 'source')
+        db.rename_column(u'cmsplugin_filer_file_filerfile', 'file_id', 'source_id')
 
     def backwards(self, orm):
-        db.rename_column(u'cmsplugin_filer_file_filerfile', 'source', 'file')
+        db.rename_column(u'cmsplugin_filer_file_filerfile', 'source_id', 'file_id')
 
     models = {
         u'auth.group': {
@@ -67,7 +67,7 @@ class Migration(SchemaMigration):
         u'cmsplugin_filer_file.filerfile': {
             'Meta': {'object_name': 'FilerFile', '_ormbases': ['cms.CMSPlugin']},
             u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'file': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
             'style': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'target_blank': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})

--- a/cmsplugin_filer_file/migrations_django/0003_rename_file_col.py
+++ b/cmsplugin_filer_file/migrations_django/0003_rename_file_col.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import filer.fields.file
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_filer_file', '0002_auto_20160112_1617'),
+    ]
+
+    operations = [
+        migrations.RenameField('filerfile', 'file', 'source'),
+    ]

--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -50,7 +50,7 @@ class FilerFile(CMSPlugin):
         if not self.source_id:
             return ''
 
-        if self.file.name in ('', None):
+        if self.source.name in ('', None):
             name = "%s" % (self.source.original_filename,)
         else:
             name = "%s" % (self.source.name,)

--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -37,17 +37,17 @@ class FilerFile(CMSPlugin):
     objects = FilerPluginManager(select_related=('source',))
 
     def get_icon_url(self):
-        if self.file_id:
+        if self.source_id:
             return self.source.icons['32']
         return ''
 
     def file_exists(self):
-        if self.file_id:
+        if self.source_id:
             return self.source.file.storage.exists(self.source.file.name)
         return False
 
     def get_file_name(self):
-        if not self.file_id:
+        if not self.source_id:
             return ''
 
         if self.file.name in ('', None):
@@ -62,7 +62,7 @@ class FilerFile(CMSPlugin):
     def __str__(self):
         if self.title:
             return self.title
-        elif self.file_id:
+        elif self.source_id:
             # added if, because it raised attribute error when file wasnt defined
             return self.get_file_name()
         return "<empty>"

--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -25,8 +25,8 @@ class FilerFile(CMSPlugin):
     STYLE_CHOICES = settings.CMSPLUGIN_FILER_FILE_STYLE_CHOICES
     DEFAULT_STYLE = settings.CMSPLUGIN_FILER_FILE_DEFAULT_STYLE
     title = models.CharField(_("title"), max_length=255, null=True, blank=True)
-    file = FilerFileField(
-        verbose_name=_('file'),
+    source = FilerFileField(
+        verbose_name=_('source'),
         null=True,
         on_delete=models.SET_NULL,
     )
@@ -34,16 +34,16 @@ class FilerFile(CMSPlugin):
     style = models.CharField(
         _('Style'), choices=STYLE_CHOICES, default=DEFAULT_STYLE, max_length=255, blank=True)
 
-    objects = FilerPluginManager(select_related=('file',))
+    objects = FilerPluginManager(select_related=('source',))
 
     def get_icon_url(self):
         if self.file_id:
-            return self.file.icons['32']
+            return self.source.icons['32']
         return ''
 
     def file_exists(self):
         if self.file_id:
-            return self.file.file.storage.exists(self.file.file.name)
+            return self.source.file.storage.exists(self.source.file.name)
         return False
 
     def get_file_name(self):
@@ -51,13 +51,13 @@ class FilerFile(CMSPlugin):
             return ''
 
         if self.file.name in ('', None):
-            name = "%s" % (self.file.original_filename,)
+            name = "%s" % (self.source.original_filename,)
         else:
-            name = "%s" % (self.file.name,)
+            name = "%s" % (self.source.name,)
         return name
 
     def get_ext(self):
-        return self.file.extension
+        return self.source.extension
 
     def __str__(self):
         if self.title:

--- a/cmsplugin_filer_file/tests.py
+++ b/cmsplugin_filer_file/tests.py
@@ -13,10 +13,10 @@ class CmsPluginFilerFileTestCase(BasePluginTestMixin,
     plugin_to_test = 'FilerFilePlugin'
 
     def get_plugin_params(self):
-        return {'file': self.get_filer_object()}
+        return {'source': self.get_filer_object()}
 
     def test_no_file(self):
-        filer_file_plugin = self._create_plugin(file=None)
+        filer_file_plugin = self._create_plugin(source=None)
         self.assertEqual(filer_file_plugin.get_file_name(), '')
         self.assertEqual(filer_file_plugin.get_icon_url(), '')
         self.assertEqual(force_text(filer_file_plugin), '<empty>')
@@ -26,8 +26,8 @@ class CmsPluginFilerFileTestCase(BasePluginTestMixin,
         # check with original file name
         self.assertEqual(filer_file_plugin.get_file_name(), 'test_file.jpg')
         # test with file name
-        filer_file_plugin.file.name = 'new_test_file_name.jpg'
-        filer_file_plugin.file.save()
+        filer_file_plugin.source.name = 'new_test_file_name.jpg'
+        filer_file_plugin.source.save()
         filer_file_plugin = filer_file_plugin._meta.model.objects.get(
             pk=filer_file_plugin.pk)
         self.assertEqual(filer_file_plugin.get_file_name(), 'new_test_file_name.jpg')
@@ -35,7 +35,7 @@ class CmsPluginFilerFileTestCase(BasePluginTestMixin,
     def test_file_exists(self):
         filer_file_plugin = self.create_plugin()
         self.assertTrue(filer_file_plugin.file_exists())
-        filer_file_plugin.file.file.delete()
+        filer_file_plugin.source.file.delete()
         self.assertFalse(filer_file_plugin.file_exists())
 
     def test_get_ext(self):

--- a/cmsplugin_filer_link/cms_plugins.py
+++ b/cmsplugin_filer_link/cms_plugins.py
@@ -17,8 +17,8 @@ class FilerLinkPlugin(CMSPluginBase):
     render_template = "cmsplugin_filer_link/link.html"
 
     def render(self, context, instance, placeholder):
-        if instance.file:
-            link = instance.file.url
+        if instance.source:
+            link = instance.source.url
         elif instance.mailto:
             link = "mailto:%s" % _(instance.mailto)
         elif instance.url:

--- a/cmsplugin_filer_link/migrations/0005_rename_file_field.py
+++ b/cmsplugin_filer_link/migrations/0005_rename_file_field.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'file', 'source')
+
+    def backwards(self, orm):
+        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'source', 'file')
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.page': {
+            'Meta': {'ordering': "('tree_id', 'lft')", 'unique_together': "(('publisher_is_draft', 'application_namespace'), ('reverse_id', 'site', 'publisher_is_draft'))", 'object_name': 'Page'},
+            'application_namespace': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'application_urls': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.CharField', [], {'max_length': '70'}),
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '70'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'is_home': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'limit_visibility_in_menu': ('django.db.models.fields.SmallIntegerField', [], {'default': 'None', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'navigation_extenders': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['cms.Page']"}),
+            'placeholders': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['cms.Placeholder']", 'symmetrical': 'False'}),
+            'publication_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'publication_end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'publisher_is_draft': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'publisher_public': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'publisher_draft'", 'unique': 'True', 'null': 'True', 'to': "orm['cms.Page']"}),
+            'reverse_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'revision_id': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'djangocms_pages'", 'to': u"orm['sites.Site']"}),
+            'soft_root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'template': ('django.db.models.fields.CharField', [], {'default': "'INHERIT'", 'max_length': '100'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'xframe_options': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'cmsplugin_filer_link.filerlinkplugin': {
+            'Meta': {'object_name': 'FilerLinkPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'file': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'link_style': ('django.db.models.fields.CharField', [], {'default': "' '", 'max_length': '255'}),
+            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'new_window': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['cmsplugin_filer_link']

--- a/cmsplugin_filer_link/migrations/0005_rename_file_field.py
+++ b/cmsplugin_filer_link/migrations/0005_rename_file_field.py
@@ -8,10 +8,10 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'file', 'source')
+        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'file_id', 'source_id')
 
     def backwards(self, orm):
-        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'source', 'file')
+        db.rename_column(u'cmsplugin_filer_link_filerlinkplugin', 'source_id', 'file_id')
 
     models = {
         u'auth.group': {
@@ -99,7 +99,7 @@ class Migration(SchemaMigration):
         u'cmsplugin_filer_link.filerlinkplugin': {
             'Meta': {'object_name': 'FilerLinkPlugin', '_ormbases': ['cms.CMSPlugin']},
             u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'file': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['filer.File']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
             'link_style': ('django.db.models.fields.CharField', [], {'default': "' '", 'max_length': '255'}),
             'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),

--- a/cmsplugin_filer_link/migrations_django/0003_rename_file_field.py
+++ b/cmsplugin_filer_link/migrations_django/0003_rename_file_field.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import filer.fields.file
+import django.db.models.deletion
+import cms.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_filer_link', '0002_auto_20160108_1710'),
+    ]
+
+    operations = [
+        migrations.RenameField('filerlinkplugin', 'file', 'source')
+    ]

--- a/cmsplugin_filer_link/models.py
+++ b/cmsplugin_filer_link/models.py
@@ -30,7 +30,7 @@ class FilerLinkPlugin(CMSPlugin):
                 choices=LINK_STYLES, default=LINK_STYLES[0][0])
     new_window = models.BooleanField(_("new window?"), default=False,
                 help_text=_("Do you want this link to open a new window?"))
-    file = FilerFileField(blank=True, null=True, on_delete=models.SET_NULL)
+    source = FilerFileField(blank=True, null=True, on_delete=models.SET_NULL)
 
     def __str__(self):
         return self.name

--- a/cmsplugin_filer_link/tests.py
+++ b/cmsplugin_filer_link/tests.py
@@ -14,7 +14,7 @@ class CmsPluginFilerLinkTestCase(BasePluginTestMixin,
         params = {
             'name': 'test link',
             'url': 'https://github.com/divio/cmsplugin-filer',
-            'file': self.get_filer_object(),
+            'source': self.get_filer_object(),
             'page_link': self.root_page,
         }
         return params

--- a/test_requirements/django_1.9.txt
+++ b/test_requirements/django_1.9.txt
@@ -1,0 +1,5 @@
+django>=1.9,<1.10
+django-reversion>=1.8.2,<1.9
+django-mptt>=0.7,<0.9
+
+-r base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     flake8
+    py27-dj19-cms32
     py27-dj18-cms31
     py27-dj{17,16}-cms{31,30}
     py26-dj{16}-cms{31,31}
@@ -15,9 +16,11 @@ deps=
     dj16: -rtest_requirements/django_1.6.txt
     dj17: -rtest_requirements/django_1.7.txt
     dj18: -rtest_requirements/django_1.8.txt
+    dj19: -rtest_requirements/django_1.9.txt
     py26: unittest2
     cms30: django-cms<3.1  # rq.filter: <3.1
     cms31: django-cms>3.1.1,<3.2  # rq.filter: >3.1.1,<3.2
+    cms32: django-cms>3.2,<3.3  # rq.filter: >3.2,<3.3
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Some new changes in Django 1.9 prevent the plugin from working as is. Made the required changes and made sure current tests pass.

Had to bump up the CMS version to 3.2 since 3.1 doesn't support Django 1.9.

---

Specifically, these errors are fixed:

    cmsplugin_filer_file.FilerFile.file: (models.E006) The field 'file' clashes with the field 'file' from model 'cms.cmsplugin'.
    cmsplugin_filer_link.FilerLinkPlugin.file: (models.E006) The field 'file' clashes with the field 'file' from model 'cms.cmsplugin'.
