### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
     - TOXENV=py27-dj17-cms30
     - TOXENV=py27-dj16-cms31
     - TOXENV=py27-dj16-cms30
-    - TOXENV=py26-dj16-cms31
-    - TOXENV=py26-dj16-cms31
 
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+toxworkdir = {homedir}/.toxenvs/cmsplugin-filer
 envlist =
     flake8
     py27-dj18-cms31

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     flake8
     py27-dj18-cms31
     py27-dj{17,16}-cms{31,30}
-    py26-dj{16}-cms{31,31}
 
 [testenv]
 commands =
@@ -15,7 +14,6 @@ deps=
     dj16: -rtest_requirements/django_1.6.txt
     dj17: -rtest_requirements/django_1.7.txt
     dj18: -rtest_requirements/django_1.8.txt
-    py26: unittest2
     cms30: django-cms<3.1  # rq.filter: <3.1
     cms31: django-cms>3.1.1,<3.2  # rq.filter: >3.1.1,<3.2
 


### PR DESCRIPTION
 - Drop Python 2.6 support as Filer does not have it either anymore
 - Tox: use dedicated toxworkdir outside of the package directory
