### PR TITLE
Fix filer dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "django-cms >= 3.1",
         "django-sekizai >= 0.4.2",
         "easy_thumbnails >= 1.0",
-        "django-filer >= 1.0.0",
+        "django-filer >= 1.2.0",
         "django-appconf",
         "djangocms-attributes-field>=0.0.2",
     ],


### PR DESCRIPTION
cmsplugin-filer 1.1 must depend on filer 1.2 as it no longer ships with ThumbnailOption model

#238 must also be merged to fix an issue with ThumbnailOption migrations