### PR TITLE
Fix model name in migration

### DIFF
--- a/cmsplugin_filer_image/migrations/0003_mv_thumbnail_option_to_filer_20160119_1720.py
+++ b/cmsplugin_filer_image/migrations/0003_mv_thumbnail_option_to_filer_20160119_1720.py
@@ -39,7 +39,7 @@ def move_thumbnail_opt_to_cms(apps, schema_editor):
                 upscale=obj.upscale
             )
         except ThumbnailOptionOld.DoesNotExist:
-            th = ThumbnailOptionNew(
+            th = ThumbnailOptionOld(
                 id=obj.id,
                 name=obj.name,
                 width=obj.width,


### PR DESCRIPTION
This fixes a typo in model name in reverse migration