### PR TITLE
Fixed styling issues with attributes field

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.1.3 (unreleased)
+------------------
+
+* Fixed styling issues with attributes field
+
 1.1.2 (2016-07-05)
 ------------------
 

--- a/cmsplugin_filer_file/forms.py
+++ b/cmsplugin_filer_file/forms.py
@@ -17,4 +17,4 @@ class FilerFileForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(FilerFileForm, self).__init__(*args, **kwargs)
-        self.fields['link_attributes'].widget = AttributesWidget(val_attrs={'style': 'width: 500px!important'})
+        self.fields['link_attributes'].widget = AttributesWidget()

--- a/cmsplugin_filer_image/forms.py
+++ b/cmsplugin_filer_image/forms.py
@@ -17,4 +17,4 @@ class FilerImageForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(FilerImageForm, self).__init__(*args, **kwargs)
-        self.fields['link_attributes'].widget = AttributesWidget(val_attrs={'style': 'width: 500px!important'})
+        self.fields['link_attributes'].widget = AttributesWidget()

--- a/cmsplugin_filer_link/forms.py
+++ b/cmsplugin_filer_link/forms.py
@@ -17,4 +17,4 @@ class FilerLinkForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(FilerLinkForm, self).__init__(*args, **kwargs)
-        self.fields['link_attributes'].widget = AttributesWidget(val_attrs={'style': 'width: 500px!important'})
+        self.fields['link_attributes'].widget = AttributesWidget()


### PR DESCRIPTION
Since divio/djangocms-attributes-field#14
it is no longer required to pass custom width for the input since
it is going to be handled correctly by the field itself.