### PR TITLE
Adjust migrations for djangoCMS 3.3.0 and 3.3.1 compatibility

### DIFF
--- a/cmsplugin_filer_file/migrations/0005_auto_20160713_1853.py
+++ b/cmsplugin_filer_file/migrations/0005_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filerfile',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_file_filerfile', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_file_filerfile', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -42,6 +42,11 @@ class FilerFile(CMSPlugin):
         _('Style'), choices=STYLE_CHOICES, default=DEFAULT_STYLE, max_length=255, blank=True)
     link_attributes = AttributesField(excluded_keys=EXCLUDED_KEYS, blank=True,
                                       help_text=_('Optional. Adds HTML attributes to the rendered link.'))
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
 
     objects = FilerPluginManager(select_related=('file',))
 

--- a/cmsplugin_filer_folder/migrations/0003_auto_20160713_1853.py
+++ b/cmsplugin_filer_folder/migrations/0003_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filerfolder',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_folder_filerfolder', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_folder_filerfolder', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_folder/models.py
+++ b/cmsplugin_filer_folder/models.py
@@ -23,6 +23,11 @@ class FilerFolder(CMSPlugin):
     folder = FilerFolderField(null=True, on_delete=models.SET_NULL)
     style = models.CharField(
         _('Style'), choices=STYLE_CHOICES, default=DEFAULT_STYLE, max_length=50)
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
 
     objects = FilerPluginManager(select_related=('folder',))
 

--- a/cmsplugin_filer_image/migrations/0009_auto_20160713_1853.py
+++ b/cmsplugin_filer_image/migrations/0009_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filerimage',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_image_filerimage', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_image_filerimage', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -76,6 +76,11 @@ class FilerImage(CMSPlugin):
     target_blank = models.BooleanField(_('Open link in new window'), default=False)
     link_attributes = AttributesField(excluded_keys=EXCLUDED_KEYS, blank=True,
                                       help_text=_('Optional. Adds HTML attributes to the rendered link.'))
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
 
     # we only add the image to select_related. page_link and file_link are FKs
     # as well, but they are not used often enough to warrant the impact of two

--- a/cmsplugin_filer_link/migrations/0007_auto_20160713_1853.py
+++ b/cmsplugin_filer_link/migrations/0007_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filerlinkplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_link_filerlinkplugin', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_link_filerlinkplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_link/models.py
+++ b/cmsplugin_filer_link/models.py
@@ -43,6 +43,11 @@ class FilerLinkPlugin(CMSPlugin):
     file = FilerFileField(blank=True, null=True, on_delete=models.SET_NULL)
     link_attributes = AttributesField(excluded_keys=EXCLUDED_KEYS, blank=True,
                                       help_text=_('Optional. Adds HTML attributes to the rendered link.'))
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
 
     def __str__(self):
         return self.name

--- a/cmsplugin_filer_teaser/migrations/0003_auto_20160713_1853.py
+++ b/cmsplugin_filer_teaser/migrations/0003_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filerteaser',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_teaser_filerteaser', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_teaser_filerteaser', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_teaser/models.py
+++ b/cmsplugin_filer_teaser/models.py
@@ -42,6 +42,12 @@ class FilerTeaser(CMSPlugin):
 
     target_blank = models.BooleanField(_("open link in new window"), default=False)
 
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
+
     objects = FilerPluginManager(select_related=('image', 'page_link'))
 
     def clean(self):

--- a/cmsplugin_filer_video/migrations/0003_auto_20160713_1853.py
+++ b/cmsplugin_filer_video/migrations/0003_auto_20160713_1853.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='filervideo',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_video_filervideo', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_filer_video_filervideo', primary_key=True, serialize=False, to='cms.CMSPlugin'),
         ),
     ]

--- a/cmsplugin_filer_video/models.py
+++ b/cmsplugin_filer_video/models.py
@@ -47,6 +47,11 @@ class FilerVideo(CMSPlugin):
     buttonoutcolor = models.CharField(_('button out color'), max_length=6, default=settings.VIDEO_BUTTON_OUT_COLOR, help_text=_('Hexadecimal, eg ff00cc'))
     buttonovercolor = models.CharField(_('button over color'), max_length=6, default=settings.VIDEO_BUTTON_OVER_COLOR, help_text=_('Hexadecimal, eg ff00cc'))
     buttonhighlightcolor = models.CharField(_('button highlight color'), max_length=6, default=settings.VIDEO_BUTTON_HIGHLIGHT_COLOR, help_text=_('Hexadecimal, eg ff00cc'))
+    cmsplugin_ptr = models.OneToOneField(
+        to=CMSPlugin,
+        related_name='%(app_label)s_%(class)s',
+        parent_link=True,
+    )
 
     def __str__(self):
         if self.movie:

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -4,5 +4,6 @@ django-appconf
 djangocms-helper>=0.9.1
 https://github.com/divio/django-filer/archive/develop.zip
 djangocms-text-ckeditor
+html5lib<0.99999999
 flake8
 django-polymorphic<0.8


### PR DESCRIPTION
djangoCMS 3.3.1 introduced a change that by default sets related_name for `cmsplugin_ptr` to ``%(app_label)s_%(class)s'``. This means that any plugin model which did not explicitly set a `cmsplugin_ptr` would automatically get this change and prompt django to ask for migrations.

To avoid incompatibilities between 3.3.0 and 3.3.1, we decided to explicitly define `cmsplugin_ptr` to match the new format on plugins that need to support both versions.