### PR TITLE
Use easy_thumbnails_tags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 * Arne Schauf
 * Benjamin Wohlwend
 * Bertrand Bordage
+* Bryan Marty
 * Claudio Bartolini
 * Cucu
 * Dan Johnson

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Dependencies
 * Django >= 1.8
 * django-cms >= 3.1
 * django-sekizai >= 0.4.2
-* easy_thumbnails >= 1.0
+* easy_thumbnails >= 2.4.1
 * django-appconf
 * djangocms-attributes-field
 

--- a/cmsplugin_filer_file/cms_plugins.py
+++ b/cmsplugin_filer_file/cms_plugins.py
@@ -58,4 +58,5 @@ class FilerFilePlugin(CMSPluginBase):
             return file_icon
         return static("filer/icons/file_%sx%s.png" % (32, 32,))
 
+
 plugin_pool.register_plugin(FilerFilePlugin)

--- a/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
+++ b/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
@@ -1,4 +1,4 @@
-{% load i18n thumbnail sekizai_tags staticfiles %}
+{% load i18n easy_thumbnails_tags sekizai_tags staticfiles %}
 {% addtoblock "css" %}<link rel="stylesheet" type="text/css" href="{% static 'cmsplugin_filer_folder/css/slideshow.css' %}" media="screen, projection" />{% endaddtoblock "css" %}
 {% addtoblock "js" %}<script type="text/javascript" src="{% static 'cmsplugin_filer_folder/js/jquery.cycle.lite-1.7.js' %}"></script>{% endaddtoblock "js" %}
 {% addtoblock "js" %}

--- a/cmsplugin_filer_image/cms_plugins.py
+++ b/cmsplugin_filer_image/cms_plugins.py
@@ -144,4 +144,6 @@ class FilerImagePlugin(CMSPluginBase):
                 return thumbnail.url
         else:
             return static("filer/icons/missingfile_%sx%s.png" % (32, 32,))
+
+
 plugin_pool.register_plugin(FilerImagePlugin)

--- a/cmsplugin_filer_image/templates/cmsplugin_filer_image/plugins/image/default.html
+++ b/cmsplugin_filer_image/templates/cmsplugin_filer_image/plugins/image/default.html
@@ -1,4 +1,4 @@
-{% load thumbnail filer_tags filer_image_tags %}{% spaceless %}
+{% load easy_thumbnails_tags filer_tags filer_image_tags %}{% spaceless %}
 {% comment %}
 	You may change the image size for special cases in your project by overriding
 	this template. There are a few size manipulation filters for this in

--- a/cmsplugin_filer_teaser/cms_plugins.py
+++ b/cmsplugin_filer_teaser/cms_plugins.py
@@ -97,4 +97,5 @@ class FilerTeaserPlugin(CMSPluginBase):
         ))
         return template
 
+
 plugin_pool.register_plugin(FilerTeaserPlugin)

--- a/cmsplugin_filer_teaser/templates/cmsplugin_filer_teaser/plugins/teaser/default.html
+++ b/cmsplugin_filer_teaser/templates/cmsplugin_filer_teaser/plugins/teaser/default.html
@@ -1,4 +1,4 @@
-{% load i18n thumbnail %}
+{% load i18n easy_thumbnails_tags %}
 <div{% if instance.style %} class="{{ instance.style }}"{% endif %}>
 <h2>{{ instance.title }}</h2>
 {% if instance.image or instance.image_url %}

--- a/cmsplugin_filer_video/cms_plugins.py
+++ b/cmsplugin_filer_video/cms_plugins.py
@@ -59,4 +59,5 @@ class FilerVideoPlugin(CMSPluginBase):
     def icon_src(self, instance):
         return static("filer/icons/video_%sx%s.png" % (32, 32,))
 
+
 plugin_pool.register_plugin(FilerVideoPlugin)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
 
         "django-cms >= 3.1",
         "django-sekizai >= 0.4.2",
-        "easy_thumbnails >= 1.0",
+        "easy_thumbnails >= 2.4.1",
         "django-appconf",
         "djangocms-attributes-field>=0.1.1",
     ],

--- a/test_settings.py
+++ b/test_settings.py
@@ -60,5 +60,6 @@ def run():
     from djangocms_helper import runner
     runner.cms('cmsplugin_filer_file')
 
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Fixes #233. Use the namespaced 'easy_thumbnails_tags' template tag instead of the 'thumbnails' template tag.