### PR TITLE
Fix: FilerPluginManager

### DIFF
--- a/cmsplugin_filer_utils/__init__.py
+++ b/cmsplugin_filer_utils/__init__.py
@@ -2,9 +2,10 @@
 from cmsplugin_filer_file import __version__  # NOQA
 
 from django.db import models
+from treebeard.mp_tree import MP_NodeManager
 
 
-class FilerPluginManager(models.Manager):
+class FilerPluginManager(MP_NodeManager):
     def __init__(self, select_related=None):
         self._select_related = select_related
         super(FilerPluginManager, self).__init__()


### PR DESCRIPTION
FilerPluginManager must inherit from MP_NodeManager to handle properly plugin deletion